### PR TITLE
Update mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,2 @@
 
-export { numeral } from './src/mod.ts';
+export { default as numeral } from './src/mod.ts';


### PR DESCRIPTION
maybe a fix for #1 

https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export

> Note: The following is syntactically invalid despite its import equivalent:

```js
import DefaultExport from 'bar.js'; // Valid
export DefaultExport from 'bar.js'; // Invalid
```

The correct way of doing this is to rename the export:

```js
export { default as DefaultExport } from 'bar.js';
```